### PR TITLE
Initial 3D Support

### DIFF
--- a/Bullet.tscn
+++ b/Bullet.tscn
@@ -1,14 +1,14 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=3 format=3 uid="uid://r66fm7ooiwd"]
 
-[ext_resource path="res://bullet.png" type="Texture2D" id=1]
+[ext_resource type="Texture2D" uid="uid://ce0uacckuahn1" path="res://bullet.png" id="1"]
 
-[sub_resource type="CircleShape2D" id=1]
+[sub_resource type="CircleShape2D" id="1"]
 radius = 5.0
 
 [node name="Bullet" type="Node2D"]
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
-texture = ExtResource( 1 )
+texture = ExtResource("1")
 
 [node name="Area2D" type="Area2D" parent="."]
 collision_layer = 2
@@ -16,4 +16,4 @@ collision_mask = 0
 monitoring = false
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Area2D"]
-shape = SubResource( 1 )
+shape = SubResource("1")

--- a/Bullet3D.tscn
+++ b/Bullet3D.tscn
@@ -1,0 +1,15 @@
+[gd_scene load_steps=3 format=3 uid="uid://ban4ayp5ge0rv"]
+
+[ext_resource type="Texture2D" uid="uid://ce0uacckuahn1" path="res://bullet.png" id="1_a23a7"]
+
+[sub_resource type="SphereShape3D" id="SphereShape3D_ep71q"]
+
+[node name="Sprite3D" type="Sprite3D"]
+pixel_size = 0.1
+billboard = 1
+texture = ExtResource("1_a23a7")
+
+[node name="Area3D" type="Area3D" parent="."]
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Area3D"]
+shape = SubResource("SphereShape3D_ep71q")

--- a/BulletMLLib.SharedProject/GameManager.cs
+++ b/BulletMLLib.SharedProject/GameManager.cs
@@ -15,6 +15,8 @@ namespace BulletMLLib.SharedProject
 		/// You need to set this at the start of the game
 		/// </summary>
 		static public FloatDelegate GameDifficulty;
+
+		static public bool UseXZ;
 	}
 }
 

--- a/BulletMLLib.SharedProject/PositionDelegate.cs
+++ b/BulletMLLib.SharedProject/PositionDelegate.cs
@@ -4,11 +4,18 @@ using Godot;
 namespace BulletMLLib.SharedProject
 {
 	/// <summary>
-	/// This is a callback method for getting a position
+	/// This is a callback method for getting a Vector2 position
 	/// used to break out dependencies
 	/// </summary>
 	/// <returns>a method to get a position.</returns>
-	public delegate Vector2 PositionDelegate();
+	public delegate Vector2 PositionDelegate2D();
+
+	/// <summary>
+	/// This is a callback method for getting a Vector3 position
+	/// used to break out dependencies
+	/// </summary>
+	/// <returns>a method to get a position.</returns>
+	public delegate Vector3 PositionDelegate3D();
 
 	/// <summary>
 	/// a method to get a float from somewhere
@@ -16,4 +23,6 @@ namespace BulletMLLib.SharedProject
 	/// </summary>
 	/// <returns>get a float from somewhere</returns>
 	public delegate float FloatDelegate();
+
+	public delegate bool BoolDelegate();
 }

--- a/Main.tscn
+++ b/Main.tscn
@@ -3,9 +3,11 @@
 [ext_resource type="Script" path="res://Main.cs" id="1"]
 [ext_resource type="PackedScene" path="res://Player/Player.tscn" id="2"]
 
-[node name="Main" type="Node2D"]
+[node name="Main" type="Node2D" node_paths=PackedStringArray("label")]
 script = ExtResource("1")
 playerScene = ExtResource("2")
+PlayerSpawnPosition = Vector2(576, -400)
+label = NodePath("Control/BulletPatternLabel")
 
 [node name="Control" type="Control" parent="."]
 layout_mode = 3

--- a/Main3D.tscn
+++ b/Main3D.tscn
@@ -1,0 +1,35 @@
+[gd_scene load_steps=3 format=3 uid="uid://c2e6i83nejcwg"]
+
+[ext_resource type="Script" path="res://Main.cs" id="1_adi6t"]
+[ext_resource type="PackedScene" uid="uid://q1ko6wm8qmah" path="res://Player/Player3D.tscn" id="2_vcre2"]
+
+[node name="Main3D" type="Node3D" node_paths=PackedStringArray("label", "playerInstance")]
+script = ExtResource("1_adi6t")
+UseXZ = true
+playerScene = ExtResource("2_vcre2")
+PlayerSpawnPosition = Vector2(0, 30)
+label = NodePath("CanvasLayer/Control/BulletPatternLabel")
+playerInstance = NodePath("Sprite3D")
+
+[node name="CanvasLayer" type="CanvasLayer" parent="."]
+
+[node name="Control" type="Control" parent="CanvasLayer"]
+layout_mode = 3
+anchors_preset = 0
+offset_right = 40.0
+offset_bottom = 40.0
+
+[node name="BulletPatternLabel" type="Label" parent="CanvasLayer/Control"]
+layout_mode = 0
+offset_left = 10.0
+offset_top = 10.0
+offset_right = 40.0
+offset_bottom = 14.0
+text = "BULLET PATTERN"
+
+[node name="Sprite3D" parent="." instance=ExtResource("2_vcre2")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 30)
+movementSpeed = 10.0
+
+[node name="Camera3D" type="Camera3D" parent="Sprite3D"]
+transform = Transform3D(1, 0, 0, 0, 0.965926, 0.258819, 0, -0.258819, 0.965926, -0.869379, 5.12404, 9.62896)

--- a/MoveManager.cs
+++ b/MoveManager.cs
@@ -10,111 +10,111 @@ namespace bulletmltemplate
   /// </summary>
   public class MoveManager : IBulletManager
   {
-    private const float timeSpeed = 1.0f;
-    private const float scale = 1.0f;
+	private const float timeSpeed = 1.0f;
+	private const float scale = 1.0f;
 
-    private readonly List<Mover> movers = new();
-    private readonly List<Mover> topLevelMovers = new();
+	private readonly List<Mover> movers = new();
+	private readonly List<Mover> topLevelMovers = new();
 
-    private readonly PositionDelegate GetPlayerPosition;
+	private readonly PositionDelegate2D GetPlayerPosition;
 
-    public MoveManager(PositionDelegate playerPosition)
-    {
-      Debug.Assert(playerPosition != null);
-      GetPlayerPosition = playerPosition;
-    }
+	public MoveManager(PositionDelegate2D playerPosition)
+	{
+	  Debug.Assert(playerPosition != null);
+	  GetPlayerPosition = playerPosition;
+	}
 
-    public void Update(float delta)
-    {
-      for (var i = 0; i < movers.Count; i++)
-      {
-        movers[i].Update();
-      }
+	public void Update(float delta)
+	{
+	  for (var i = 0; i < movers.Count; i++)
+	  {
+		movers[i].Update();
+	  }
 
-      for (var i = 0; i < topLevelMovers.Count; i++)
-      {
-        topLevelMovers[i].Update();
-      }
+	  for (var i = 0; i < topLevelMovers.Count; i++)
+	  {
+		topLevelMovers[i].Update();
+	  }
 
-      FreeMovers();
-    }
+	  FreeMovers();
+	}
 
-    private void FreeMovers()
-    {
-      for (var i = 0; i < movers.Count; i++)
-      {
-        if (movers[i].Used) continue;
-        movers.RemoveAt(i);
-        i--;
-      }
+	private void FreeMovers()
+	{
+	  for (var i = 0; i < movers.Count; i++)
+	  {
+		if (movers[i].Used) continue;
+		movers.RemoveAt(i);
+		i--;
+	  }
 
-      //clear out top level bullets
-      for (var i = 0; i < topLevelMovers.Count; i++)
-      {
-        if (!topLevelMovers[i].TasksFinished()) continue;
-        topLevelMovers.RemoveAt(i);
-        i--;
-      }
-    }
+	  //clear out top level bullets
+	  for (var i = 0; i < topLevelMovers.Count; i++)
+	  {
+		if (!topLevelMovers[i].TasksFinished()) continue;
+		topLevelMovers.RemoveAt(i);
+		i--;
+	  }
+	}
 
-    public Vector2 PlayerPosition(IBullet targettedBullet)
-    {
-      //just give the player's position
-      Debug.Assert(null != GetPlayerPosition);
-      return GetPlayerPosition();
-    }
+	public Vector2 PlayerPosition(IBullet targettedBullet)
+	{
+	  //just give the player's position
+	  Debug.Assert(null != GetPlayerPosition);
+	  return GetPlayerPosition();
+	}
 
-    public void RemoveBullet(IBullet deadBullet)
-    {
-      if (deadBullet is Mover myMover)
-      {
-        myMover.Used = false;
-      }
-    }
+	public void RemoveBullet(IBullet deadBullet)
+	{
+	  if (deadBullet is Mover myMover)
+	  {
+		myMover.Used = false;
+	  }
+	}
 
-    public IBullet CreateBullet()
-    {
-      var mover = new Mover(this) { TimeSpeed = timeSpeed, Scale = scale };
+	public IBullet CreateBullet()
+	{
+	  var mover = new Mover(this) { TimeSpeed = timeSpeed, Scale = scale };
 
-      //initialize, store in our list, and return the bullet
-      mover.Init();
-      movers.Add(mover);
-      return mover;
-    }
+	  //initialize, store in our list, and return the bullet
+	  mover.Init();
+	  movers.Add(mover);
+	  return mover;
+	}
 
-    public IBullet CreateTopBullet()
-    {
-      var mover = new Mover(this) { TimeSpeed = timeSpeed, Scale = scale };
+	public IBullet CreateTopBullet()
+	{
+	  var mover = new Mover(this) { TimeSpeed = timeSpeed, Scale = scale };
 
-      //initialize, store in our list, and return the bullet
-      mover.Init();
-      topLevelMovers.Add(mover);
-      return mover;
-    }
+	  //initialize, store in our list, and return the bullet
+	  mover.Init();
+	  topLevelMovers.Add(mover);
+	  return mover;
+	}
 
-    public double Tier()
-    {
-      return 0.0;
-    }
+	public double Tier()
+	{
+	  return 0.0;
+	}
 
-    public void Clear()
-    {
-      movers.Clear();
-      topLevelMovers.Clear();
-    }
+	public void Clear()
+	{
+	  movers.Clear();
+	  topLevelMovers.Clear();
+	}
 
-    public void PostUpdate()
-    {
-      // TODO: use godot game loop
-      foreach (var t in movers)
-      {
-        t.PostUpdate();
-      }
+	public void PostUpdate()
+	{
+	  // TODO: use godot game loop
+	  foreach (var t in movers)
+	  {
+		t.PostUpdate();
+	  }
 
-      foreach (var t in topLevelMovers)
-      {
-        t.PostUpdate();
-      }
-    }
+	  foreach (var t in topLevelMovers)
+	  {
+		t.PostUpdate();
+	  }
+	}
   }
 }

--- a/Mover.cs
+++ b/Mover.cs
@@ -8,70 +8,73 @@ namespace bulletmltemplate
   /// </summary>
   public class Mover : Bullet
   {
-    private bool used;
-    private Node2D ParentNode { get; set; }
-    private Node2D BulletNode { get; set; }
+	private bool used;
+	private float bulletLifetime = 5;
+	private Node ParentNode { get; set; }
+	private Node BulletNode { get; set; }
 
-    public Mover(IBulletManager myBulletManager) : base(myBulletManager)
-    {
-    }
+	public Mover(IBulletManager myBulletManager) : base(myBulletManager)
+	{
+	}
 
-    public override void PostUpdate()
-    {
-      // something something out of bounds
-      if (X < 0f || X > Main.ViewportWidth || Y < 0f || Y > Main.ViewportHeight)
-      {
-        Used = false;
-      }
-    }
+	public override void PostUpdate()
+	{
+	  // something something out of bounds
+	  if (X < 0f || X > Main.Viewport.X || Y < 0f || Y > Main.Viewport.Y)
+	  {
+		Used = false;
+	  }
+	}
   
-    public override float X
-    {
-      get => Position.X;
-      set
-      { 
-        var position = Position;
-        position.X = value;
-        Position = position;
-      
-        BulletNode.Position = Position;
-      }
-    }
+	public override float X
+	{
+	  get => Position.X;
+	  set
+	  { 
+		var position = Position;
+		position.X = value;
+		Position = position;
+	  
+		if (GameManager.UseXZ)(BulletNode as Node3D).Position = new Vector3(position.X,  0, position.Y);
+		else (BulletNode as Node2D).Position = Position;
+	  }
+	}
 
-    public override float Y
-    {
-      get => Position.Y;
-      set
-      { 
-        var position = Position;
-        position.Y = value;
-        Position = position;
-      
-        BulletNode.Position = Position;
-      }
-    }
+	public override float Y
+	{
+	  get => Position.Y;
+	  set
+	  { 
+		var position = Position;
+		position.Y = value;
+		Position = position;
+		if (GameManager.UseXZ)(BulletNode as Node3D).Position = new Vector3(position.X,  0, position.Y);
+		else (BulletNode as Node2D).Position = Position;
+	  }
+	}
   
-    public Vector2 Position { get; set; }
+	public Vector2 Position { get; set; }
 
-    public bool Used
-    {
-      get => used;
-      set
-      {
-        used = value;
-        BulletNode.Visible = value;
-      }
-    }
+	public bool Used
+	{
+	  get => used;
+	  set
+	  {
+		used = value;
+		if (GameManager.UseXZ) (BulletNode as Node3D).Visible = value;
+		else (BulletNode as Node2D).Visible = value;
+		BulletNode.ProcessMode = value ? Node.ProcessModeEnum.Always : Node.ProcessModeEnum.Disabled;
+	  }
+	}
 
 
-    public void Init()
-    {
-      ParentNode = Main.Instance;
-      var scene = ResourceLoader.Load<PackedScene>("Bullet.tscn");
-      BulletNode = scene.Instantiate() as Node2D;
-      ParentNode.AddChild(BulletNode);
-    
-      Used = true;
-    }
+	public void Init()
+	{
+	  ParentNode = Main.Instance;
+	  var scene = ResourceLoader.Load<PackedScene>(GameManager.UseXZ?"Bullet3D.tscn":"Bullet.tscn");
+	  BulletNode = scene.Instantiate();
+	  ParentNode.AddChild(BulletNode);
+	  Used = true;
+	}
   }
 }

--- a/Player/Player.cs
+++ b/Player/Player.cs
@@ -6,39 +6,39 @@ public partial class Player : Sprite2D
 
   public override void _Process(double _delta)
   {
-    var delta = (float)_delta;
-    base._Process(delta);
+	var delta = (float)_delta;
+	base._Process(delta);
 
-    var movement = new Vector2();
+	var movement = new Vector2();
 
-    if (Input.IsActionPressed("ui_right"))
-    {
-      movement += Vector2.Right;
-    }
-    else if (Input.IsActionPressed("ui_left"))
-    {
-      movement += Vector2.Left;
-    }
+	if (Input.IsActionPressed("ui_right"))
+	{
+	  movement += Vector2.Right;
+	}
+	else if (Input.IsActionPressed("ui_left"))
+	{
+	  movement += Vector2.Left;
+	}
 
-    if (Input.IsActionPressed("ui_up"))
-    {
-      movement += Vector2.Up;
-    }
-    else if (Input.IsActionPressed("ui_down"))
-    {
-      movement += Vector2.Down;
-    }
+	if (Input.IsActionPressed("ui_up"))
+	{
+	  movement += Vector2.Up;
+	}
+	else if (Input.IsActionPressed("ui_down"))
+	{
+	  movement += Vector2.Down;
+	}
 
-    Position += movement.Normalized() * movementSpeed * delta;
+	Position += movement.Normalized() * movementSpeed * delta;
 
-    var position = Position;
-    position.X = Mathf.Clamp(position.X, 0f, GetViewportRect().Size.X);
-    position.Y = Mathf.Clamp(position.Y, 0f, GetViewportRect().Size.Y);
-    Position = position;
+	var position = Position;
+	position.X = Mathf.Clamp(position.X, 0f, GetViewportRect().Size.X);
+	position.Y = Mathf.Clamp(position.Y, 0f, GetViewportRect().Size.Y);
+	Position = position;
   }
 
   private void _on_Area2D_area_entered(Node area)
   {
-    GetNode<AnimationPlayer>(nameof(AnimationPlayer)).Play("hit");
+	GetNode<AnimationPlayer>(nameof(AnimationPlayer)).Play("hit");
   }
 }

--- a/Player/Player3D.cs
+++ b/Player/Player3D.cs
@@ -1,0 +1,30 @@
+using Godot;
+
+public partial class Player3D : Node3D
+{
+  [Export] private float movementSpeed = 400f;
+
+  public override void _Process(double _delta)
+  {
+	var delta = (float)_delta;
+	base._Process(delta);
+
+	var movement = new Vector3();
+
+	if (Input.IsActionPressed("ui_right"))     movement += Vector3.Right;
+	else if (Input.IsActionPressed("ui_left")) movement += Vector3.Left;
+
+	if (Input.IsActionPressed("ui_up"))        movement += Vector3.Forward;
+	else if (Input.IsActionPressed("ui_down")) movement += Vector3.Back;
+
+	Position += movement.Normalized() * movementSpeed * delta;
+
+	var position = Position;
+	Position = position;
+  }
+
+  private void _on_Area3D_area_entered(Node area)
+  {
+	  GetNode<AnimationPlayer>(nameof(AnimationPlayer)).Play("hit");
+  }
+}

--- a/Player/Player3D.tscn
+++ b/Player/Player3D.tscn
@@ -1,0 +1,67 @@
+[gd_scene load_steps=8 format=3 uid="uid://q1ko6wm8qmah"]
+
+[ext_resource type="Texture2D" uid="uid://df8yamhadj7jv" path="res://textures.png" id="1_u6brj"]
+[ext_resource type="Script" path="res://Player/Player3D.cs" id="2_u13vn"]
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_168sf"]
+atlas = ExtResource("1_u6brj")
+region = Rect2(128, 56, 16, 16)
+
+[sub_resource type="SphereShape3D" id="SphereShape3D_tixvh"]
+radius = 1.0
+
+[sub_resource type="Animation" id="Animation_vm7v4"]
+resource_name = "hit"
+step = 0.05
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath(".:modulate")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.2, 0.4, 0.6, 0.8, 1),
+"transitions": PackedFloat32Array(1, 1, 1, 1, 1, 1),
+"update": 0,
+"values": [Color(1, 1, 1, 0), Color(1, 1, 1, 1), Color(1, 1, 1, 0), Color(1, 1, 1, 1), Color(1, 1, 1, 0), Color(1, 1, 1, 1)]
+}
+
+[sub_resource type="Animation" id="Animation_nsmnx"]
+length = 0.001
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath(".:modulate")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Color(1, 1, 1, 1)]
+}
+
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_30rhd"]
+_data = {
+"RESET": SubResource("Animation_nsmnx"),
+"hit": SubResource("Animation_vm7v4")
+}
+
+[node name="Sprite3D" type="Sprite3D"]
+pixel_size = 0.1
+billboard = 1
+texture = SubResource("AtlasTexture_168sf")
+script = ExtResource("2_u13vn")
+movementSpeed = 5.0
+
+[node name="Area3D" type="Area3D" parent="."]
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Area3D"]
+shape = SubResource("SphereShape3D_tixvh")
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="."]
+libraries = {
+"": SubResource("AnimationLibrary_30rhd")
+}
+
+[connection signal="area_entered" from="Area3D" to="." method="_on_Area3D_area_entered"]

--- a/bullet.png.import
+++ b/bullet.png.import
@@ -3,25 +3,26 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://ce0uacckuahn1"
-path="res://.godot/imported/bullet.png-ff1424653e10246c11e3724e402c519e.ctex"
+path.s3tc="res://.godot/imported/bullet.png-ff1424653e10246c11e3724e402c519e.s3tc.ctex"
 metadata={
-"vram_texture": false
+"imported_formats": ["s3tc_bptc"],
+"vram_texture": true
 }
 
 [deps]
 
 source_file="res://bullet.png"
-dest_files=["res://.godot/imported/bullet.png-ff1424653e10246c11e3724e402c519e.ctex"]
+dest_files=["res://.godot/imported/bullet.png-ff1424653e10246c11e3724e402c519e.s3tc.ctex"]
 
 [params]
 
-compress/mode=0
+compress/mode=2
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
 compress/normal_map=0
 compress/channel_pack=0
-mipmaps/generate=false
+mipmaps/generate=true
 mipmaps/limit=-1
 roughness/mode=0
 roughness/src_normal=""
@@ -31,4 +32,4 @@ process/normal_map_invert_y=false
 process/hdr_as_srgb=false
 process/hdr_clamp_exposure=false
 process/size_limit=0
-detect_3d/compress_to=1
+detect_3d/compress_to=0

--- a/bulletml-template.csproj
+++ b/bulletml-template.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Godot.NET.Sdk/4.0.1">
+<Project Sdk="Godot.NET.Sdk/4.1.2">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <EnableDynamicLoading>true</EnableDynamicLoading>

--- a/bulletml-template.csproj.old.1
+++ b/bulletml-template.csproj.old.1
@@ -1,0 +1,9 @@
+<Project Sdk="Godot.NET.Sdk/4.0.1">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Equationator" Version="1.0.4" />
+  </ItemGroup>
+</Project>

--- a/project.godot
+++ b/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="bulletml-template"
 run/main_scene="res://Main.tscn"
-config/features=PackedStringArray("4.0", "C#")
+config/features=PackedStringArray("4.1", "C#")
 config/icon="res://icon.png"
 
 [dotnet]

--- a/textures.png.import
+++ b/textures.png.import
@@ -3,25 +3,26 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://df8yamhadj7jv"
-path="res://.godot/imported/textures.png-7de323d84b704158a1297173214775ac.ctex"
+path.s3tc="res://.godot/imported/textures.png-7de323d84b704158a1297173214775ac.s3tc.ctex"
 metadata={
-"vram_texture": false
+"imported_formats": ["s3tc_bptc"],
+"vram_texture": true
 }
 
 [deps]
 
 source_file="res://textures.png"
-dest_files=["res://.godot/imported/textures.png-7de323d84b704158a1297173214775ac.ctex"]
+dest_files=["res://.godot/imported/textures.png-7de323d84b704158a1297173214775ac.s3tc.ctex"]
 
 [params]
 
-compress/mode=0
+compress/mode=2
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
 compress/normal_map=0
 compress/channel_pack=0
-mipmaps/generate=false
+mipmaps/generate=true
 mipmaps/limit=-1
 roughness/mode=0
 roughness/src_normal=""
@@ -31,4 +32,4 @@ process/normal_map_invert_y=false
 process/hdr_as_srgb=false
 process/hdr_clamp_exposure=false
 process/size_limit=0
-detect_3d/compress_to=1
+detect_3d/compress_to=0


### PR DESCRIPTION
This adds initial support for 3D Nodes. Certain things were altered such as Node2D -> Node with a UseXZ check, which was inspired by UniBulletHelll's Axis selection. This only adds checks to convert Positions to `Vetor3(Position.x, 0, Position.y)` it doesn't seem to support some features yet? 
I'm not very knowledgeable in BulletML yet, so I'll investigate what's broken, but I suspect it's in Bullet.cs at this time.
